### PR TITLE
fix: use latest Promise polyfill without protocol

### DIFF
--- a/src/multivalue.html
+++ b/src/multivalue.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -6,7 +6,7 @@
     <title>Multi Values Control</title>
     <link rel="stylesheet" href="multi-selection.css"/>
     <!-- for ie -->
-    <script src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
+    <script src="//www.promisejs.org/polyfills/promise-7.0.4.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Dropping the protocol Fixes #104.
Bumped to the latest version and used the minified version at the same time.