### PR TITLE
Fix #128 Custom Value Casing

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1.0,
     "id": "vsts-extensions-multivalue-control",
-    "version": "2.2.28",
+    "version": "2.2.29",
     "name": "Multivalue control",
     "description": "A work item form control which allows selection of multiple values.",
     "publisher": "ms-devlabs",

--- a/src/MultiValueControl.tsx
+++ b/src/MultiValueControl.tsx
@@ -159,7 +159,7 @@ export class MultiValueControl extends React.Component<IMultiValueControlProps, 
             ...opts.filter((o) => o.toLocaleLowerCase().indexOf(filter) === 0),
             ...opts.filter((o) => o.toLocaleLowerCase().indexOf(filter) > 0),
         ];
-        return filtered.length === 0 && this._allowCustom ? [filter] : filtered;
+        return filtered.length === 0 && this._allowCustom ? [this.state.filter] : filtered;
     }
     private _onInputChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         let isMultiline = this.state.multiline;


### PR DESCRIPTION
Custom values entered by the user are lower-cased for matching purposes in the filter. When this value is returned to be displayed and saved however, it should be in its original state--not lower-cased.

Issue #128 