### PR TITLE
Fix data selection and truncation bugs, better support long label lengths

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -104,6 +104,14 @@
                             "dataType": "Boolean",
                             "isRequired": false
                         }
+                    },
+                    {
+                        "id":"LabelDisplayLength",
+                        "name": "Set the maximum display length for each option's label. Defaults to 35 if not set.",
+                        "validation": {
+                            "dataType": "Number",
+                            "isRequired": false
+                        }
                     }
 				]
             }

--- a/src/MultiValueControl.tsx
+++ b/src/MultiValueControl.tsx
@@ -31,6 +31,7 @@ export class MultiValueControl extends React.Component<IMultiValueControlProps, 
    
     private readonly _unfocusedTimeout = BrowserCheckUtils.isSafari() ? 2000 : 1;
     private readonly _allowCustom: boolean = VSS.getConfiguration().witInputs.AllowCustom;
+    private readonly _labelDisplayLength: number = VSS.getConfiguration().witInputs.LabelDisplayLength ? VSS.getConfiguration().witInputs.LabelDisplayLength : 35;
     private _setUnfocused = new DelayedFunction(null, this._unfocusedTimeout, "", () => {
         this.setState({focused: false, filter: ""});
     });
@@ -104,13 +105,14 @@ export class MultiValueControl extends React.Component<IMultiValueControlProps, 
                     }}
                     onChange={() => this._toggleOption(o)}
                     label={this._wrapText(o)}
+                    title={o}
                 />)}
             </FocusZone>
         </div>;
     }
 
     private _wrapText(text: string){
-        return text.length > 15 ? `${text.slice(0,35)}...` : text;
+        return text.length > this._labelDisplayLength ? `${text.slice(0,this._labelDisplayLength)}...` : text;
     }
     private _onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.altKey || e.shiftKey || e.ctrlKey) {

--- a/src/MultiValueEvents.tsx
+++ b/src/MultiValueEvents.tsx
@@ -57,7 +57,7 @@ export class MultiValueEvents {
         if (typeof value !== "string") {
             return [];
         }
-        return value.split(";").filter((v) => !!v);
+        return value.split(";").filter((v) => !!v).map(s => s.trim());
     }
     private _setSelected = async (values: string[]): Promise<void> => {
         this.refresh(values);

--- a/src/getSuggestedValues.ts
+++ b/src/getSuggestedValues.ts
@@ -4,7 +4,7 @@ export async function getSuggestedValues(): Promise<string[]> {
     const inputs: IDictionaryStringTo<string> = VSS.getConfiguration().witInputs;
     const valuesString: string = inputs.Values;
     if (valuesString) {
-        return valuesString.split(";").filter((v) => !!v);
+        return valuesString.split(";").filter((v) => !!v).map(s => s.trim());
     }
     // if the values input were not specified as an input, get the suggested values for the field.
     const service = await WorkItemFormService.getService();

--- a/xmldetails.md
+++ b/xmldetails.md
@@ -33,6 +33,10 @@ Extension:
 			Data Type: String
 			IsRequired: false
 
+            Id: LabelDisplayLength
+            Description: Set the maximum display length for each option's label. Defaults to 35 if not set.
+            Data Type: Number
+            IsRequired: false
 
 Note: For more information on work item extensions use the following topic:
 http://go.microsoft.com/fwlink/?LinkId=816513
@@ -104,6 +108,11 @@ You can find the contribution ID and input information within the commented blob
 			Description: Values can be user provided or from suggested values of the backing field
 			Data Type: String
 			IsRequired: false
+
+            Id: LabelDisplayLength
+            Description: Display length of the label. Defaults to 35 if not set.
+            Data Type: Number
+            IsRequired: false
 ```
 
 For the input tag, the content of the `Id` attribute can be either `FieldName` or `Values`.


### PR DESCRIPTION
I've combined these changes into one PR in the hope it will be easier for you to review and merge. Let me know if you need me to separate the changes out to separate PRs.

I've addressed a few of the most significant quality of life changes we need as a large enterprise user of this field. Specifically:
1. #217 
Added trim() where the data is matched for selection in the UI when determining which checkboxes are checked. Will fix matching issues without affecting the underlying data.

2. #208 
Added a configuration field to specify the maximum label length for each field. Defaults to 35 (current behaviour) if not set.
Added a 'title' to each option with the full length label to show on mouse-over. Whilst this is not an optimal solution from an accessibility perspective I think it significantly improves the UX of long values for many users. 

3. #207 
Updated the wrapText function to ensure the append length and trunc length are the same (previously 15 and 35 respectively).