### PR TITLE
Fixes #307: Filter out semicolon separated values to prevent them from showing up as separate options.

### DIFF
--- a/.azure-devops/azure-pipelines.yml
+++ b/.azure-devops/azure-pipelines.yml
@@ -24,7 +24,7 @@ resources:
   repositories:
     - repository: pipeline-templates
       type: git
-      name: Sage/pipeline-templates
+      name: DevLabs Extensions/pipeline-templates
       ref: main
 
 stages:

--- a/src/MultiValueControl.tsx
+++ b/src/MultiValueControl.tsx
@@ -106,7 +106,7 @@ export class MultiValueControl extends React.Component<IMultiValueControlProps, 
                         onFocus: this._onFocus,
                     }}
                     onChange={() => this._toggleOption(o)}
-                    label={this._wrapText(o.length > 30 ? `${o.slice(0, 30)}...` : o)}
+                    label={this._wrapText(o)}
                     title={o}
                 />)}
             </FocusZone>

--- a/src/getSuggestedValues.ts
+++ b/src/getSuggestedValues.ts
@@ -8,5 +8,10 @@ export async function getSuggestedValues(): Promise<string[]> {
     }
     // if the values input were not specified as an input, get the suggested values for the field.
     const service = await WorkItemFormService.getService();
-    return await service.getAllowedFieldValues(VSS.getConfiguration().witInputs.FieldName) as string[];
+    const allowedValues = await service.getAllowedFieldValues(VSS.getConfiguration().witInputs.FieldName) as string[];
+
+    // getAllowedFieldValues API now returns both predefined and user-selected values.
+    // When multiple options are selected, these are stored as a semicolon-separated string.
+    // Filter out these user-selected values to prevent them from showing up as separate options.
+    return allowedValues.filter((value) => value.indexOf(";") === -1);
 }


### PR DESCRIPTION
This PR fixes #307, where the multivalue control displayed saved semicolon-separated values alongside the predefined list of values. This was due to a change in the `getAllowedFieldValues` API, which now returns both predefined and user-saved values.

**Testing:**
* Verified that the dropdown no longer shows duplicate values.
* Confirmed that predefined values without semicolons are still correctly displayed.
* Tested with both 'Allow users to enter custom values' selected and unselected.

@AminTi 