### PR TITLE
Reverted onblur to use reset instead of start

### DIFF
--- a/src/MultiValueControl.tsx
+++ b/src/MultiValueControl.tsx
@@ -237,7 +237,7 @@ export class MultiValueControl extends React.Component<
   };
 
   private _onBlur = () => {
-    this._setUnfocused.start();
+    this._setUnfocused.reset();
   };
   private _onFocus = () => {
     this._setUnfocused.cancel();


### PR DESCRIPTION
This pull request makes a minor update to the focus handling logic in the `MultiValueControl` component. The change ensures that the unfocused state timer is reset rather than started when the component loses focus.