### PR TITLE
Dark mode text in dropdown is now more visible

### DIFF
--- a/src/multi-selection.scss
+++ b/src/multi-selection.scss
@@ -33,6 +33,7 @@
   }
   .text {
     @include color(--palette-neutral-100, 0, 0, 0);
+    color: var(--text-primary-color, inherit) !important;
   }
   .customTagPicker {
     display: flex;
@@ -90,11 +91,19 @@
   .options {
     button {
       width: 100%;
+      color: var(--text-primary-color, inherit) !important;
       &:hover {
         @include background-color(--palette-primary-tint-40, 239, 246, 252);
       }
       .ms-Checkbox-text {
         @include color(--palette-neutral-100, 0, 0, 0);
+        color: var(--text-primary-color, inherit) !important;
+      }
+      label {
+        color: var(--text-primary-color, inherit) !important;
+      }
+      span {
+        color: var(--text-primary-color, inherit) !important;
       }
     }
     .checkboxes {
@@ -103,6 +112,10 @@
     input {
       @include color(--palette-neutral-100, 0, 0, 0);
       @include background-color(--palette-neutral-0, 255, 255, 255);
+    }
+    // Add general text color override for all children
+    * {
+      color: var(--text-primary-color, inherit) !important;
     }
   }
   .error {


### PR DESCRIPTION
This pull request updates the styling in `src/multi-selection.scss` to ensure consistent use of the `--text-primary-color` CSS variable throughout the multi-selection component. The changes focus on overriding text color for various elements to improve theme support and maintain visual consistency.

**Theme consistency and text color overrides:**

* Added `color: var(--text-primary-color, inherit) !important;` to the `.text` class to enforce the primary text color.
* Applied the same text color override to buttons, checkbox text, labels, and spans within the `.options` section for uniformity.
* Introduced a general override for all child elements within `.options` using the universal selector (`*`), ensuring all text uses the primary color.