### PR TITLE
Centralization of semicolon-delimited value handling for the multi-value control by introducing a shared codec utility

### DIFF
--- a/src/MultiValueEvents.tsx
+++ b/src/MultiValueEvents.tsx
@@ -6,6 +6,7 @@ import { WorkItemFormService } from "TFS/WorkItemTracking/Services";
 
 import { getSuggestedValues } from "./getSuggestedValues";
 import { MultiValueControl } from "./MultiValueControl";
+import { parseMultiValueFieldValue, serializeMultiValueFieldValue } from "./valueCodec";
 
 initializeIcons();
 const HELP_URL = "https://github.com/Microsoft/vsts-extension-multivalue-control#azure-devops-services";
@@ -54,10 +55,7 @@ export class MultiValueEvents {
     private async _getSelected(): Promise<string[]> {
         const formService = await WorkItemFormService.getService();
         const value = await formService.getFieldValue(this.fieldName);
-        if (typeof value !== "string") {
-            return [];
-        }
-        return value.split(";").filter((v) => !!v).map(s => s.trim());
+        return parseMultiValueFieldValue(value);
     }
     private _setSelected = async (values: string[]): Promise<void> => {
         const formService = await WorkItemFormService.getService();
@@ -76,7 +74,7 @@ export class MultiValueEvents {
         }
         this.refresh(values);
         this._fired++;
-        await formService.setFieldValue(this.fieldName, values.join(";"));
+        await formService.setFieldValue(this.fieldName, serializeMultiValueFieldValue(values));
 
         return new Promise<void>((resolve) => {
             this._onRefreshed = resolve;

--- a/src/getSuggestedValues.ts
+++ b/src/getSuggestedValues.ts
@@ -1,10 +1,11 @@
 import { WorkItemFormService } from "TFS/WorkItemTracking/Services";
+import { parseMultiValueFieldValue } from "./valueCodec";
 
 export async function getSuggestedValues(): Promise<string[]> {
     const inputs: IDictionaryStringTo<string> = VSS.getConfiguration().witInputs;
     const valuesString: string = inputs.Values;
     if (valuesString) {
-        return valuesString.split(";").filter((v) => !!v).map(s => s.trim());
+        return parseMultiValueFieldValue(valuesString);
     }
     // if the values input were not specified as an input, get the suggested values for the field.
     const service = await WorkItemFormService.getService();

--- a/src/valueCodec.ts
+++ b/src/valueCodec.ts
@@ -18,12 +18,3 @@ export function serializeMultiValueFieldValue(values: string[]): string {
         .filter((value) => !!value)
         .join(";");
 }
-
-/**
- * Allowed-values picklists validate the entire stored field value.
- * Joining multiple values with ';' creates a single combined value that
- * will not exist in a single-select allowed-values list.
- */
-export function isAllowedValueCompatible(values: string[]): boolean {
-    return values.length <= 1;
-}

--- a/src/valueCodec.ts
+++ b/src/valueCodec.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared parser/serializer for semicolon-delimited field values.
+ */
+export function parseMultiValueFieldValue(value: unknown): string[] {
+    if (typeof value !== "string") {
+        return [];
+    }
+
+    return value
+        .split(";")
+        .map((item) => item.trim())
+        .filter((item) => !!item);
+}
+
+export function serializeMultiValueFieldValue(values: string[]): string {
+    return values
+        .map((value) => value.trim())
+        .filter((value) => !!value)
+        .join(";");
+}
+
+/**
+ * Allowed-values picklists validate the entire stored field value.
+ * Joining multiple values with ';' creates a single combined value that
+ * will not exist in a single-select allowed-values list.
+ */
+export function isAllowedValueCompatible(values: string[]): boolean {
+    return values.length <= 1;
+}


### PR DESCRIPTION
Dear,

This change refactors multi-value field handling to use a single shared codec so parsing and serialization are consistent across the extension.

Changed files

[valueCodec.ts]
Added shared parsing logic for semicolon-delimited values.
Added shared serialization logic that trims entries, removes empty values, and joins with semicolons.
Added compatibility helper for allowed-values behavior.
[MultiValueEvents.tsx]
Replaced inline split/trim parsing with shared codec parsing.
Replaced inline join serialization with shared codec serialization.
[getSuggestedValues.ts]
Replaced inline split/trim parsing of configured Values input with shared codec parsing.

Sample values

Input selections:
Customer A
Customer B
Serialized value:
Customer A;Customer B
Parsed result:
Customer A
Customer B

Outcome

One canonical implementation for value parsing/serialization.
Cleaner maintenance and fewer inconsistencies between read/write paths.